### PR TITLE
make txexpr a match-expander

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
   global:
     - RACKET_DIR=~/racket
   matrix:
-    - RACKET_VERSION=6.0
     - RACKET_VERSION=6.0.1
  #   - RACKET_VERSION=6.1
  #   - RACKET_VERSION=6.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     - RACKET_DIR=~/racket
   matrix:
     - RACKET_VERSION=6.0
+    - RACKET_VERSION=6.0.1
  #   - RACKET_VERSION=6.1
  #   - RACKET_VERSION=6.2
     - RACKET_VERSION=6.3

--- a/txexpr/private/define-provide-safe-match.rkt
+++ b/txexpr/private/define-provide-safe-match.rkt
@@ -6,7 +6,8 @@
          (for-syntax racket/base
                      racket/syntax
                      syntax/parse
-                     syntax/stx))
+                     syntax/stx
+                     version/utils))
 
 ;; (define+provide+safe+match name-id
 ;;   contract-expr
@@ -50,6 +51,10 @@
        #:with internal-name (generate-temporary #'name)
        #:with contract-name (generate-temporary #'name)
        #:with make-name-match-transformer (generate-temporary #'name)
+       #:with [name-for-blame ...]
+       (cond [(version<=? "6.8" (version)) #'[#:name-for-blame name]]
+             [else                         #'[]])
+
        #'(begin
            (define internal-name (let ([name value]) name))
 
@@ -67,7 +72,7 @@
              (require racket/contract/base)
 
              (define-module-boundary-contract contract-name internal-name contract
-               #:name-for-blame name)
+               name-for-blame ...)
 
              (define-match-expander name
                (make-name-match-transformer (quote-syntax contract-name))

--- a/txexpr/private/define-provide-safe-match.rkt
+++ b/txexpr/private/define-provide-safe-match.rkt
@@ -1,0 +1,76 @@
+#lang racket/base
+
+(provide define+provide+safe+match)
+
+(require racket/match
+         syntax/parse/define
+         (for-syntax racket/base
+                     racket/syntax
+                     syntax/parse
+                     syntax/stx))
+
+;; (define+provide+safe+match name-id
+;;   contract-expr
+;;   value-expr
+;;   #:match-expander
+;;   match-transformer-expr)
+;; 
+;; (define+provide+safe+match (head . args)
+;;   contract-expr
+;;   value-body-expr
+;;   ...+
+;;   #:match-expander
+;;   match-transformer-expr)
+
+(begin-for-syntax
+  ;; Identifier -> [Syntax -> Syntax]
+  (define ((variable-like-transformer id) stx)
+    (cond
+      [(identifier? stx)
+       ; id, but with the source location of stx
+       (datum->syntax id (syntax-e id) stx id)]
+      [(stx-pair? stx)
+       (datum->syntax stx (cons id (stx-cdr stx)) stx stx)])))
+
+(define-syntax-parser define+provide+safe+match
+
+  [(d (head . args)
+      contract:expr
+      value-body:expr ...+
+      #:match-expander match-transformer:expr)
+   #:with fn-expr (syntax/loc this-syntax (λ args value-body ...))
+   (syntax/loc this-syntax
+     (d head contract fn-expr #:match-expander match-transformer))]
+
+  [(_ name:id
+      contract:expr
+      value:expr
+      #:match-expander match-transformer:expr)
+   #:with internal-name (generate-temporary #'name)
+   #:with contract-name (generate-temporary #'name)
+   #:with make-name-match-transformer (generate-temporary #'name)
+   #'(begin
+       (define internal-name (let ([name value]) name))
+
+       (begin-for-syntax
+         (define (make-name-match-transformer name)
+           (with-syntax ([name name]) match-transformer)))
+
+       (define-match-expander name
+         (make-name-match-transformer (quote-syntax internal-name))
+         (variable-like-transformer (quote-syntax internal-name)))
+
+       (provide name)
+
+       (module+ safe
+         (require racket/contract/base)
+
+         (define-module-boundary-contract contract-name internal-name contract
+           #:name-for-blame name)
+
+         (define-match-expander name
+           (make-name-match-transformer (quote-syntax contract-name))
+           (variable-like-transformer (quote-syntax contract-name)))
+
+         (provide name)))])
+

--- a/txexpr/private/define-provide-safe-match.rkt
+++ b/txexpr/private/define-provide-safe-match.rkt
@@ -3,7 +3,6 @@
 (provide define+provide+safe+match)
 
 (require racket/match
-         syntax/parse/define
          (for-syntax racket/base
                      racket/syntax
                      syntax/parse
@@ -32,45 +31,47 @@
       [(stx-pair? stx)
        (datum->syntax stx (cons id (stx-cdr stx)) stx stx)])))
 
-(define-syntax-parser define+provide+safe+match
+(define-syntax define+provide+safe+match
+  (λ (stx)
+    (syntax-parse stx
 
-  [(d (head . args)
-      contract:expr
-      value-body:expr ...+
-      #:match-expander match-transformer:expr)
-   #:with fn-expr (syntax/loc this-syntax (λ args value-body ...))
-   (syntax/loc this-syntax
-     (d head contract fn-expr #:match-expander match-transformer))]
+      [(d (head . args)
+          contract:expr
+          value-body:expr ...+
+          #:match-expander match-transformer:expr)
+       #:with fn-expr (syntax/loc stx (λ args value-body ...))
+       (syntax/loc stx
+         (d head contract fn-expr #:match-expander match-transformer))]
 
-  [(_ name:id
-      contract:expr
-      value:expr
-      #:match-expander match-transformer:expr)
-   #:with internal-name (generate-temporary #'name)
-   #:with contract-name (generate-temporary #'name)
-   #:with make-name-match-transformer (generate-temporary #'name)
-   #'(begin
-       (define internal-name (let ([name value]) name))
+      [(_ name:id
+          contract:expr
+          value:expr
+          #:match-expander match-transformer:expr)
+       #:with internal-name (generate-temporary #'name)
+       #:with contract-name (generate-temporary #'name)
+       #:with make-name-match-transformer (generate-temporary #'name)
+       #'(begin
+           (define internal-name (let ([name value]) name))
 
-       (begin-for-syntax
-         (define (make-name-match-transformer name)
-           (with-syntax ([name name]) match-transformer)))
+           (begin-for-syntax
+             (define (make-name-match-transformer name)
+               (with-syntax ([name name]) match-transformer)))
 
-       (define-match-expander name
-         (make-name-match-transformer (quote-syntax internal-name))
-         (variable-like-transformer (quote-syntax internal-name)))
+           (define-match-expander name
+             (make-name-match-transformer (quote-syntax internal-name))
+             (variable-like-transformer (quote-syntax internal-name)))
 
-       (provide name)
+           (provide name)
 
-       (module+ safe
-         (require racket/contract/base)
+           (module+ safe
+             (require racket/contract/base)
 
-         (define-module-boundary-contract contract-name internal-name contract
-           #:name-for-blame name)
+             (define-module-boundary-contract contract-name internal-name contract
+               #:name-for-blame name)
 
-         (define-match-expander name
-           (make-name-match-transformer (quote-syntax contract-name))
-           (variable-like-transformer (quote-syntax contract-name)))
+             (define-match-expander name
+               (make-name-match-transformer (quote-syntax contract-name))
+               (variable-like-transformer (quote-syntax contract-name)))
 
-         (provide name)))])
+             (provide name)))])))
 

--- a/txexpr/test/contract-tests.rkt
+++ b/txexpr/test/contract-tests.rkt
@@ -1,0 +1,16 @@
+#lang racket/base
+
+(require (submod "../main.rkt" safe))
+(module+ test
+  (require rackunit))
+
+(module+ test
+  (check-exn (regexp (string-append
+                      "txexpr: contract violation\n"
+                      " *expected: txexpr-tag\\?\n"
+                      " *given: 4\n"
+                      " *in: the 1st argument.*"
+                      " *blaming: .*test/contract-tests.rkt"))
+             (λ () (txexpr 4)))
+  )
+

--- a/txexpr/test/contract-tests.rkt
+++ b/txexpr/test/contract-tests.rkt
@@ -6,7 +6,7 @@
 
 (module+ test
   (check-exn (regexp (string-append
-                      "txexpr: contract violation\n"
+                      "txexpr.*: contract violation\n"
                       " *expected: txexpr-tag\\?\n"
                       " *given: 4\n"
                       " *in: the 1st argument.*"

--- a/txexpr/test/tests.rkt
+++ b/txexpr/test/tests.rkt
@@ -108,6 +108,19 @@
                (txexpr->list '(p ((key "value")))))
  (check-equal? (values->list (txexpr->values '(p ((key "value")) "foo"))) 
                (txexpr->list '(p ((key "value")) "foo")))
+
+ ;; testing the match expander success
+ (check-match '(p ((key "value")) "leaf")
+              (txexpr 'p `((key ,val)) (list "leaf"))
+              (string=? val "value"))
+
+ ;; testing the match expander failure
+ (check-false (match '(p ((key "value")) "something")
+                [(txexpr 'p _ (list "else")) #true]
+                [_                           #false]))
+ (check-false (match "foo"
+                [(txexpr _ _ _) #true]
+                [_              #false]))
  
  (check-equal? (get-tag '(p ((key "value"))"foo" "bar" (em "square"))) 'p)
  (check-equal? (get-attrs '(p ((key "value"))"foo" "bar" (em "square"))) '((key "value")))


### PR DESCRIPTION
Closes #7. 

```racket
> (match '(p ((key "value")) "leaf")
    [(txexpr 'p `((key ,val)) (list "leaf")) val])
"value"
```
