### PR TITLE
Expose deleted-signal with docs correction

### DIFF
--- a/txexpr/base.rkt
+++ b/txexpr/base.rkt
@@ -261,7 +261,7 @@
               x))))
 
 ;; function to split tag out of txexpr
-(define+provide+safe deleted-signal symbol? (gensym))
+(define deleted-signal #f)
 (define+provide+safe (splitf-txexpr tx pred [proc (λ (x) deleted-signal)])
   ((txexpr? procedure?) (procedure?) . ->* . (values txexpr? txexpr-elements?))
   (unless (txexpr? tx)

--- a/txexpr/base.rkt
+++ b/txexpr/base.rkt
@@ -261,8 +261,7 @@
               x))))
 
 ;; function to split tag out of txexpr
-(define deleted-signal #f)
-(define+provide+safe (splitf-txexpr tx pred [proc (λ (x) deleted-signal)])
+(define+provide+safe (splitf-txexpr tx pred [proc (λ (x) #f)])
   ((txexpr? procedure?) (procedure?) . ->* . (values txexpr? txexpr-elements?))
   (unless (txexpr? tx)
     (raise-argument-error 'splitf-txexpr "txexpr?" tx))
@@ -273,8 +272,7 @@
        (set! matches (cons x matches))
        (proc x)]
       [(? txexpr?) (let-values ([(tag attrs elements) (txexpr->values x)]) 
-                     (txexpr-unsafe tag attrs (filter-not (λ (e) (eq? e deleted-signal))
-                                                          (map extract! elements))))]
+                     (txexpr-unsafe tag attrs (filter values (map extract! elements))))]
       [_ x]))
   (define tx-extracted (extract! tx)) ;; do this first to fill matches
   (values tx-extracted (reverse matches)))

--- a/txexpr/base.rkt
+++ b/txexpr/base.rkt
@@ -6,7 +6,6 @@
          (for-syntax racket/base syntax/parse))
 (provide cdata? cdata valid-char? xexpr->string xexpr?) ; from xml
 (provide empty) ; from racket/list
-(provide deleted-signal)
 
 ;; Section 2.2 of XML 1.1
 ;; (XML 1.0 is slightly different and more restrictive)
@@ -262,7 +261,7 @@
               x))))
 
 ;; function to split tag out of txexpr
-(define deleted-signal (gensym))
+(define+provide+safe deleted-signal symbol? (gensym))
 (define+provide+safe (splitf-txexpr tx pred [proc (λ (x) deleted-signal)])
   ((txexpr? procedure?) (procedure?) . ->* . (values txexpr? txexpr-elements?))
   (unless (txexpr? tx)

--- a/txexpr/base.rkt
+++ b/txexpr/base.rkt
@@ -6,6 +6,7 @@
          (for-syntax racket/base syntax/parse))
 (provide cdata? cdata valid-char? xexpr->string xexpr?) ; from xml
 (provide empty) ; from racket/list
+(provide deleted-signal)
 
 ;; Section 2.2 of XML 1.1
 ;; (XML 1.0 is slightly different and more restrictive)

--- a/txexpr/scribblings/txexpr.scrbl
+++ b/txexpr/scribblings/txexpr.scrbl
@@ -469,12 +469,18 @@ In practice, most @racket[_txexpr-element]s are strings. But it's unwise to pass
 ]
 
 
+@deftogether[(
+
+@defthing[deleted-signal symbol?]
+
 @defproc[
 (splitf-txexpr
 [tx txexpr?]
 [pred procedure?]
-[replace-proc procedure? (λ (x) null)])
+[replace-proc procedure? (λ (x) deleted-signal)])
 (values txexpr? (listof txexpr-element?))]
+
+)]
 Recursively descend through @racket[_txexpr] and extract all elements that match @racket[_pred]. Returns two values: a @racket[_txexpr] with the matching elements removed, and the list of matching elements. Sort of esoteric, but I've needed it more than once, so here it is.
 
 @examples[#:eval my-eval
@@ -483,7 +489,7 @@ Recursively descend through @racket[_txexpr] and extract all elements that match
 (splitf-txexpr tx is-meta?)
 ]
 
-Ordinarily, the result of the split operation is to remove the elements that match @racket[_pred]. But you can change this behavior with the optional @racket[_replace-proc] argument.
+Ordinarily, the result of the split operation is to remove the elements that match @racket[_pred]. This happens only when returning @racket[_deleted-signal]. You can change this behavior with the optional @racket[_replace-proc] argument.
 
 @examples[#:eval my-eval
 (define tx '(div "Wonderful day" (meta "weather" "good") "for a walk"))

--- a/txexpr/scribblings/txexpr.scrbl
+++ b/txexpr/scribblings/txexpr.scrbl
@@ -469,18 +469,12 @@ In practice, most @racket[_txexpr-element]s are strings. But it's unwise to pass
 ]
 
 
-@deftogether[(
-
-@defthing[deleted-signal symbol?]
-
 @defproc[
 (splitf-txexpr
 [tx txexpr?]
 [pred procedure?]
-[replace-proc procedure? (λ (x) deleted-signal)])
+[replace-proc procedure? (λ (x) #f)])
 (values txexpr? (listof txexpr-element?))]
-
-)]
 Recursively descend through @racket[_txexpr] and extract all elements that match @racket[_pred]. Returns two values: a @racket[_txexpr] with the matching elements removed, and the list of matching elements. Sort of esoteric, but I've needed it more than once, so here it is.
 
 @examples[#:eval my-eval
@@ -489,7 +483,7 @@ Recursively descend through @racket[_txexpr] and extract all elements that match
 (splitf-txexpr tx is-meta?)
 ]
 
-Ordinarily, the result of the split operation is to remove the elements that match @racket[_pred]. This happens only when returning @racket[_deleted-signal]. You can change this behavior with the optional @racket[_replace-proc] argument.
+Ordinarily, the result of the split operation is to remove the elements that match @racket[_pred]. But you can change this behavior with the optional @racket[_replace-proc] argument.
 
 @examples[#:eval my-eval
 (define tx '(div "Wonderful day" (meta "weather" "good") "for a walk"))


### PR DESCRIPTION
@mbutterick The docs say that `(λ (x) null)` is the default `replace-proc` for `splitf-txexpr`.
This disagrees with the code, which uses `deleted-signal`. Since there is a use case for conditionally removing elements, I put in a `(provide deleted-signal)` and corrected the docs.