### PR TITLE
Improve specificity of errors in validate-txexpr

### DIFF
--- a/txexpr/scribblings/txexpr.scrbl
+++ b/txexpr/scribblings/txexpr.scrbl
@@ -195,7 +195,7 @@ Predicate for functions that handle @racket[_txexpr-attrs]. Covers values that a
 (validate-txexpr
 [possible-txexpr any/c])
 txexpr?]
-Like @racket[txexpr?], but raise a descriptive error if @racket[_possible-txexpr] is invalid, and otherwise return @racket[_possible-txexpr] itself.
+Like @racket[txexpr?], but raise a descriptive error pinpointing the first problem encountered if @racket[_possible-txexpr] is invalid, and otherwise return @racket[_possible-txexpr] itself.
 
 @examples[#:eval my-eval
 (validate-txexpr 'root)
@@ -204,6 +204,8 @@ Like @racket[txexpr?], but raise a descriptive error if @racket[_possible-txexpr
 (validate-txexpr '(root ((id "top")(class "42"))))
 (validate-txexpr '(root ((id "top")(class "42")) ("hi")))
 (validate-txexpr '(root ((id "top")(class "42")) "hi"))
+(validate-txexpr '(root (p "Hello " (span [[class "inner"]] (1 2 3)))))
+(validate-txexpr `(root (p "Look out" (span ,(void)) (1 2 3))))
 ]
 
 


### PR DESCRIPTION
Makes `validate-texpr` recursive and tries to be as specific as possible about the problem:

```racket
;; This txexpr has two problems
(validate-txexpr `(fine-outer ((id "top") (class "42")) (div (p (span [["type" "1"]] ,(void) )))))
validate-txexpr: attribute key is not a symbol
  attribute key: "type"
  in: '(span (("type" "1")) #<void>)

;; After fixing the first one
(validate-txexpr `(fine-outer ((id "top") (class "42")) (div (p (span [[type "1"]] ,(void) )))))
validate-txexpr: element not a valid element (= txexpr, string, symbol, XML char, or cdata)
  element: #<void>
  in: '(span ((type "1")) #<void>)
```

Also fixes cases where errors can sometimes be misleading; for example, in the current version:

```racket
;; Problem is malformed attrs in p tag, but error points at 1st element of fine-outer
(validate-txexpr  '(fine-outer "no problem" "\n" (p [[href "#"] class "hidden"] "Hello!")))
validate-txexpr-attrs: contract violation
  expected: 
   in '(fine-outer "no problem" "\n" (p ((href "#") class "hidden") "Hello!")), list of 
attributes, each in the form '(symbol "string")
  given: "no problem"
```

In this version:

```racket
(validate-txexpr  '(fine-outer "no problem" "\n" (p [[href "#"] class "hidden"] "Hello!")))
validate-txexpr: attribute is not a list of the form '(symbol "string")
  attribute: 'class
  in: '(p ((href "#") class "hidden") "Hello!")
```